### PR TITLE
[libc++] Replace std::memmove/memcpy with __builtin_memmove/memcpy

### DIFF
--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -25,7 +25,6 @@
 #include <__utility/swap.h>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <limits>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -40,7 +39,7 @@ _Size
 __loadword(const void* __p)
 {
     _Size __r;
-    _VSTD::memcpy(&__r, __p, sizeof(__r));
+    ::__builtin_memcpy(&__r, __p, sizeof(__r));
     return __r;
 }
 

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -30,7 +30,6 @@
 #include <__utility/pair.h>
 #include <__utility/swap.h>
 #include <cmath>
-#include <cstring>
 #include <initializer_list>
 #include <type_traits>
 
@@ -1528,7 +1527,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::__deallocate_node(__next_pointer __np)
             {
                 (*__p)->__c_ = nullptr;
                 if (--__c->end_ != __p)
-                    _VSTD::memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
+                    ::__builtin_memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
             }
         }
         __get_db()->unlock();
@@ -2503,7 +2502,7 @@ __hash_table<_Tp, _Hash, _Equal, _Alloc>::remove(const_iterator __p) _NOEXCEPT
         {
             (*__dp)->__c_ = nullptr;
             if (--__c->end_ != __dp)
-                _VSTD::memmove(__dp, __dp+1, (__c->end_ - __dp)*sizeof(__i_node*));
+                ::__builtin_memmove(__dp, __dp+1, (__c->end_ - __dp)*sizeof(__i_node*));
         }
     }
     __get_db()->unlock();

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -703,6 +703,7 @@ _LIBCPP_END_NAMESPACE_STD
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <concepts>
+#  include <cstring>
 #  include <iosfwd>
 #  include <iterator>
 #  include <memory>

--- a/libcxx/include/atomic
+++ b/libcxx/include/atomic
@@ -1247,9 +1247,9 @@ bool __cxx_atomic_compare_exchange_strong(__cxx_atomic_lock_impl<_Tp>* __a,
   __a->__lock();
   bool __ret = (_VSTD::memcmp(&__a->__a_value, __expected, sizeof(_Tp)) == 0);
   if(__ret)
-    _VSTD::memcpy(&__a->__a_value, &__value, sizeof(_Tp));
+    ::__builtin_memcpy(&__a->__a_value, &__value, sizeof(_Tp));
   else
-    _VSTD::memcpy(__expected, &__a->__a_value, sizeof(_Tp));
+    ::__builtin_memcpy(__expected, &__a->__a_value, sizeof(_Tp));
   __a->__unlock();
   return __ret;
 }
@@ -1276,9 +1276,9 @@ bool __cxx_atomic_compare_exchange_weak(__cxx_atomic_lock_impl<_Tp>* __a,
   __a->__lock();
   bool __ret = (_VSTD::memcmp(&__a->__a_value, __expected, sizeof(_Tp)) == 0);
   if(__ret)
-    _VSTD::memcpy(&__a->__a_value, &__value, sizeof(_Tp));
+    ::__builtin_memcpy(&__a->__a_value, &__value, sizeof(_Tp));
   else
-    _VSTD::memcpy(__expected, &__a->__a_value, sizeof(_Tp));
+    ::__builtin_memcpy(__expected, &__a->__a_value, sizeof(_Tp));
   __a->__unlock();
   return __ret;
 }

--- a/libcxx/include/barrier
+++ b/libcxx/include/barrier
@@ -330,6 +330,7 @@ _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstring>
 #  include <iterator>
 #  include <memory>
 #  include <stdexcept>

--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -270,6 +270,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstring>
 #  include <type_traits>
 #endif
 

--- a/libcxx/include/coroutine
+++ b/libcxx/include/coroutine
@@ -56,6 +56,7 @@ struct suspend_always;
 #endif
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstring>
 #  include <iosfwd>
 #  include <type_traits>
 #endif

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -2434,6 +2434,7 @@ _LIBCPP_POP_MACROS
 #  include <algorithm>
 #  include <atomic>
 #  include <concepts>
+#  include <cstring>
 #  include <functional>
 #  include <iosfwd>
 #  include <iterator>

--- a/libcxx/include/experimental/coroutine
+++ b/libcxx/include/experimental/coroutine
@@ -56,6 +56,7 @@ template <class P> struct hash<coroutine_handle<P>>;
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <atomic>
 #  include <climits>
+#  include <cstring>
 #  include <cmath>
 #  include <compare>
 #  include <concepts>

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -1794,6 +1794,7 @@ _LIBCPP_POP_MACROS
 #  include <algorithm>
 #  include <atomic>
 #  include <concepts>
+#  include <cstring>
 #  include <functional>
 #  include <iosfwd>
 #  include <iterator>

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -438,22 +438,22 @@ basic_filebuf<_CharT, _Traits>::swap(basic_filebuf& __rhs)
             // *this uses the small buffer, but __rhs doesn't.
             __extbuf_ = __rhs.__extbuf_;
             __rhs.__extbuf_ = __rhs.__extbuf_min_;
-            std::memmove(__rhs.__extbuf_min_, __extbuf_min_, sizeof(__extbuf_min_));
+            ::__builtin_memmove(__rhs.__extbuf_min_, __extbuf_min_, sizeof(__extbuf_min_));
         }
         else if (__extbuf_ != __extbuf_min_ && __rhs.__extbuf_ == __rhs.__extbuf_min_)
         {
             // *this doesn't use the small buffer, but __rhs does.
             __rhs.__extbuf_ = __extbuf_;
             __extbuf_ = __extbuf_min_;
-            std::memmove(__extbuf_min_, __rhs.__extbuf_min_, sizeof(__extbuf_min_));
+            ::__builtin_memmove(__extbuf_min_, __rhs.__extbuf_min_, sizeof(__extbuf_min_));
         }
         else
         {
             // Both *this and __rhs use the small buffer.
             char __tmp[sizeof(__extbuf_min_)];
-            std::memmove(__tmp, __extbuf_min_, sizeof(__extbuf_min_));
-            std::memmove(__extbuf_min_, __rhs.__extbuf_min_, sizeof(__extbuf_min_));
-            std::memmove(__rhs.__extbuf_min_, __tmp, sizeof(__extbuf_min_));
+            ::__builtin_memcpy(__tmp, __extbuf_min_, sizeof(__extbuf_min_));
+            ::__builtin_memmove(__extbuf_min_, __rhs.__extbuf_min_, sizeof(__extbuf_min_));
+            ::__builtin_memcpy(__rhs.__extbuf_min_, __tmp, sizeof(__extbuf_min_));
         }
         __extbufnext_ = __extbuf_ + __rn;
         __extbufend_ = __extbuf_ + __re;
@@ -738,7 +738,7 @@ basic_filebuf<_CharT, _Traits>::underflow()
     int_type __c = traits_type::eof();
     if (this->gptr() == this->egptr())
     {
-        _VSTD::memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
+        ::__builtin_memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
         if (__always_noconv_)
         {
             size_t __nmemb = static_cast<size_t>(this->egptr() - this->eback() - __unget_sz);
@@ -756,7 +756,7 @@ basic_filebuf<_CharT, _Traits>::underflow()
             if (__extbufend_ != __extbufnext_) {
                 _LIBCPP_ASSERT(__extbufnext_ != nullptr, "underflow moving from nullptr");
                 _LIBCPP_ASSERT(__extbuf_ != nullptr, "underflow moving into nullptr");
-                _VSTD::memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
+                ::__builtin_memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
             }
             __extbufnext_ = __extbuf_ + (__extbufend_ - __extbufnext_);
             __extbufend_ = __extbuf_ + (__extbuf_ == __extbuf_min_ ? sizeof(__extbuf_min_) : __ebs_);

--- a/libcxx/include/functional
+++ b/libcxx/include/functional
@@ -543,6 +543,7 @@ POLICY:  For non-variadic implementations, the number of arguments is limited
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstring>
 #  include <tuple>
 #  include <utility>
 #endif

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -207,7 +207,6 @@ template <class T, class Allocator, class Predicate>
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/swap.h>
-#include <cstring>
 #include <limits>
 #include <type_traits>
 #include <version>
@@ -785,7 +784,7 @@ __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
         {
             __cn2->__add(*__p);
             if (--__cn1->end_ != __p)
-                _VSTD::memmove(__p, __p+1, (__cn1->end_ - __p)*sizeof(__i_node*));
+                ::__builtin_memmove(__p, __p+1, (__cn1->end_ - __p)*sizeof(__i_node*));
         }
         else
             (*__p)->__c_ = __cn1;
@@ -798,7 +797,7 @@ __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
         {
             __cn1->__add(*__p);
             if (--__cn2->end_ != __p)
-                _VSTD::memmove(__p, __p+1, (__cn2->end_ - __p)*sizeof(__i_node*));
+                ::__builtin_memmove(__p, __p+1, (__cn2->end_ - __p)*sizeof(__i_node*));
         }
         else
             (*__p)->__c_ = __cn2;
@@ -1658,7 +1657,7 @@ list<_Tp, _Alloc>::pop_front()
         {
             (*__p)->__c_ = nullptr;
             if (--__c->end_ != __p)
-                _VSTD::memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
+                ::__builtin_memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
         }
     }
     __get_db()->unlock();
@@ -1687,7 +1686,7 @@ list<_Tp, _Alloc>::pop_back()
         {
             (*__p)->__c_ = nullptr;
             if (--__c->end_ != __p)
-                _VSTD::memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
+                ::__builtin_memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
         }
     }
     __get_db()->unlock();
@@ -1720,7 +1719,7 @@ list<_Tp, _Alloc>::erase(const_iterator __p)
         {
             (*__ip)->__c_ = nullptr;
             if (--__c->end_ != __ip)
-                _VSTD::memmove(__ip, __ip+1, (__c->end_ - __ip)*sizeof(__i_node*));
+                ::__builtin_memmove(__ip, __ip+1, (__c->end_ - __ip)*sizeof(__i_node*));
         }
     }
     __get_db()->unlock();
@@ -1758,7 +1757,7 @@ list<_Tp, _Alloc>::erase(const_iterator __f, const_iterator __l)
                 {
                     (*__p)->__c_ = nullptr;
                     if (--__c->end_ != __p)
-                        _VSTD::memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
+                        ::__builtin_memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
                 }
             }
             __get_db()->unlock();
@@ -1900,7 +1899,7 @@ list<_Tp, _Alloc>::splice(const_iterator __p, list& __c)
                     __cn1->__add(*__ip);
                     (*__ip)->__c_ = __cn1;
                     if (--__cn2->end_ != __ip)
-                        _VSTD::memmove(__ip, __ip+1, (__cn2->end_ - __ip)*sizeof(__i_node*));
+                        ::__builtin_memmove(__ip, __ip+1, (__cn2->end_ - __ip)*sizeof(__i_node*));
                 }
             }
             __db->unlock();
@@ -1941,7 +1940,7 @@ list<_Tp, _Alloc>::splice(const_iterator __p, list& __c, const_iterator __i)
                     __cn1->__add(*__ip);
                     (*__ip)->__c_ = __cn1;
                     if (--__cn2->end_ != __ip)
-                        _VSTD::memmove(__ip, __ip+1, (__cn2->end_ - __ip)*sizeof(__i_node*));
+                        ::__builtin_memmove(__ip, __ip+1, (__cn2->end_ - __ip)*sizeof(__i_node*));
                 }
             }
             __db->unlock();
@@ -2005,7 +2004,7 @@ list<_Tp, _Alloc>::splice(const_iterator __p, list& __c, const_iterator __f, con
                         __cn1->__add(*__ip);
                         (*__ip)->__c_ = __cn1;
                         if (--__cn2->end_ != __ip)
-                            _VSTD::memmove(__ip, __ip+1, (__cn2->end_ - __ip)*sizeof(__i_node*));
+                            ::__builtin_memmove(__ip, __ip+1, (__cn2->end_ - __ip)*sizeof(__i_node*));
                     }
                 }
             }
@@ -2138,7 +2137,7 @@ list<_Tp, _Alloc>::merge(list& __c, _Comp __comp)
                 __cn1->__add(*__p);
                 (*__p)->__c_ = __cn1;
                 if (--__cn2->end_ != __p)
-                    _VSTD::memmove(__p, __p+1, (__cn2->end_ - __p)*sizeof(__i_node*));
+                    ::__builtin_memmove(__p, __p+1, (__cn2->end_ - __p)*sizeof(__i_node*));
             }
         }
         __db->unlock();
@@ -2377,6 +2376,7 @@ _LIBCPP_POP_MACROS
 #  include <algorithm>
 #  include <atomic>
 #  include <concepts>
+#  include <cstring>
 #  include <functional>
 #  include <iosfwd>
 #  include <iterator>

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -3993,7 +3993,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
     int_type __c = traits_type::eof();
     if (this->gptr() == this->egptr())
     {
-        _VSTD::memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
+        ::__builtin_memmove(this->eback(), this->egptr() - __unget_sz, __unget_sz * sizeof(char_type));
         if (__always_noconv_)
         {
             streamsize __nmemb = static_cast<streamsize>(this->egptr() - this->eback() - __unget_sz);
@@ -4011,7 +4011,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
              if (__extbufend_ != __extbufnext_) {
                 _LIBCPP_ASSERT(__extbufnext_ != nullptr, "underflow moving from nullptr");
                 _LIBCPP_ASSERT(__extbuf_ != nullptr, "underflow moving into nullptr");
-                _VSTD::memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
+                ::__builtin_memmove(__extbuf_, __extbufnext_, __extbufend_ - __extbufnext_);
              }
             __extbufnext_ = __extbuf_ + (__extbufend_ - __extbufnext_);
             __extbufend_ = __extbuf_ + (__extbuf_ == __extbuf_min_ ? sizeof(__extbuf_min_) : __ebs_);

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -705,6 +705,7 @@ _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstring>
 #  include <functional>
 #  include <type_traits>
 #endif

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -1578,6 +1578,7 @@ _LIBCPP_END_NAMESPACE_STD
 #  include <atomic>
 #  include <climits>
 #  include <concepts>
+#  include <cstring>
 #  include <ctime>
 #  include <iterator>
 #  include <memory>

--- a/libcxx/include/ostream
+++ b/libcxx/include/ostream
@@ -1190,6 +1190,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstring>
 #  include <iterator>
 #  include <type_traits>
 #endif

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -570,7 +570,6 @@ basic_string<char32_t> operator "" s( const char32_t *str, size_t len );        
 #include <cstdint>
 #include <cstdio>  // EOF
 #include <cstdlib>
-#include <cstring>
 #include <limits>
 #include <stdexcept>
 #include <string_view>
@@ -2060,7 +2059,7 @@ basic_string<_CharT, _Traits, _Allocator>::__invalidate_iterators_past(size_type
                 {
                     (*__p)->__c_ = nullptr;
                     if (--__c->end_ != __p)
-                        std::memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
+                        ::__builtin_memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
                 }
             }
             __get_db()->unlock();

--- a/libcxx/include/system_error
+++ b/libcxx/include/system_error
@@ -160,6 +160,10 @@ template <> struct hash<std::error_condition>;
 // [system.error.syn]
 #include <compare>
 
+#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstring>
+#endif
+
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif

--- a/libcxx/include/thread
+++ b/libcxx/include/thread
@@ -104,6 +104,10 @@ void sleep_for(const chrono::duration<Rep, Period>& rel_time);
 // [thread.syn]
 #include <compare>
 
+#if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstring>
+#endif
+
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
 #endif

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -2647,6 +2647,7 @@ _LIBCPP_END_NAMESPACE_STD
 #  include <algorithm>
 #  include <bit>
 #  include <concepts>
+#  include <cstring>
 #  include <iterator>
 #endif
 

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -1817,6 +1817,7 @@ _LIBCPP_END_NAMESPACE_STD
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #  include <concepts>
+#  include <cstring>
 #  include <functional>
 #  include <iterator>
 #endif

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -1831,6 +1831,7 @@ _LIBCPP_END_NAMESPACE_STD
 _LIBCPP_POP_MACROS
 
 #if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
+#  include <cstring>
 #  include <type_traits>
 #  include <typeinfo>
 #  include <utility>

--- a/libcxx/include/vector
+++ b/libcxx/include/vector
@@ -314,7 +314,6 @@ template<class T, class charT> requires is-vector-bool-reference<T> // Since C++
 #include <__utility/swap.h>
 #include <climits>
 #include <cstdlib>
-#include <cstring>
 #include <iosfwd> // for forward declaration of vector
 #include <limits>
 #include <stdexcept>
@@ -2032,7 +2031,7 @@ vector<_Tp, _Allocator>::__invalidate_iterators_past(pointer __new_last) {
     if (__i->base() > __new_last) {
       (*__p)->__c_ = nullptr;
       if (--__c->end_ != __p)
-        std::memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
+        ::__builtin_memmove(__p, __p+1, (__c->end_ - __p)*sizeof(__i_node*));
     }
   }
   __get_db()->unlock();


### PR DESCRIPTION
This allows us to eliminate some transitive includes of `<cstring>`, and also makes the whole codebase consistent with the style adopted in commit 5629d492df388bf6b5532a2a5c1ef5fd27d65ab0 ([D139235](https://reviews.llvm.org/D139235)).

This is relevant to my interests because P1144 wants to use `(__builtin_)memcpy` inside `std::swap`, and if I'm able to use the new non-`<cstring>`-including style there, that'll shrink the P1144 diff. So it would be convenient to have this commit as confirmation that the new style is indeed acceptable everywhere — that there's not some subtle reason we're intentionally avoiding `__builtin_memcpy` in these other places.