### PR TITLE
[libc++] Fix "size_t" constants that should be "bool" or "int", and add tests

### DIFF
--- a/libcxx/include/__functional/bind.h
+++ b/libcxx/include/__functional/bind.h
@@ -32,7 +32,7 @@ struct is_bind_expression : _If<
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
-inline constexpr size_t is_bind_expression_v = is_bind_expression<_Tp>::value;
+inline constexpr bool is_bind_expression_v = is_bind_expression<_Tp>::value;
 #endif
 
 template<class _Tp>
@@ -44,7 +44,7 @@ struct is_placeholder : _If<
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
-inline constexpr size_t is_placeholder_v = is_placeholder<_Tp>::value;
+inline constexpr int is_placeholder_v = is_placeholder<_Tp>::value;
 #endif
 
 namespace placeholders

--- a/libcxx/include/__memory/uses_allocator.h
+++ b/libcxx/include/__memory/uses_allocator.h
@@ -51,7 +51,7 @@ struct _LIBCPP_TEMPLATE_VIS uses_allocator
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class _Alloc>
-inline constexpr size_t uses_allocator_v = uses_allocator<_Tp, _Alloc>::value;
+inline constexpr bool uses_allocator_v = uses_allocator<_Tp, _Alloc>::value;
 #endif
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/test/std/utilities/function.objects/bind/func.bind/func.bind.isbind/is_bind_expression.pass.cpp
+++ b/libcxx/test/std/utilities/function.objects/bind/func.bind/func.bind.isbind/is_bind_expression.pass.cpp
@@ -23,8 +23,10 @@ test(const T&)
     LIBCPP_STATIC_ASSERT(std::is_bind_expression<T&>::value == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_bind_expression<const T>::value == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_bind_expression<const T&>::value == Expected, "");
+    static_assert(std::is_base_of<std::integral_constant<bool, Expected>, std::is_bind_expression<T> >::value, "");
 
 #if TEST_STD_VER > 14
+    ASSERT_SAME_TYPE(decltype(std::is_bind_expression_v<T>), const bool);
     static_assert(std::is_bind_expression_v<T> == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_bind_expression_v<T&> == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_bind_expression_v<const T> == Expected, "");

--- a/libcxx/test/std/utilities/function.objects/bind/func.bind/func.bind.isplace/is_placeholder.pass.cpp
+++ b/libcxx/test/std/utilities/function.objects/bind/func.bind/func.bind.isplace/is_placeholder.pass.cpp
@@ -21,8 +21,13 @@ test(const T&)
     LIBCPP_STATIC_ASSERT(std::is_placeholder<T&>::value == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_placeholder<const T>::value == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_placeholder<const T&>::value == Expected, "");
+    static_assert(std::is_base_of<std::integral_constant<int, Expected>, std::is_placeholder<T> >::value, "");
+    LIBCPP_STATIC_ASSERT(std::is_base_of<std::integral_constant<int, Expected>, std::is_placeholder<T&> >::value, "");
+    LIBCPP_STATIC_ASSERT(std::is_base_of<std::integral_constant<int, Expected>, std::is_placeholder<const T> >::value, "");
+    LIBCPP_STATIC_ASSERT(std::is_base_of<std::integral_constant<int, Expected>, std::is_placeholder<const T&> >::value, "");
 
 #if TEST_STD_VER > 14
+    ASSERT_SAME_TYPE(decltype(std::is_placeholder_v<T>), const int);
     static_assert(std::is_placeholder_v<T> == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_placeholder_v<T&> == Expected, "");
     LIBCPP_STATIC_ASSERT(std::is_placeholder_v<const T> == Expected, "");

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.trait/uses_allocator.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.trait/uses_allocator.pass.cpp
@@ -42,7 +42,9 @@ void
 test()
 {
     static_assert((std::uses_allocator<T, A>::value == Expected), "");
+    static_assert(std::is_base_of<std::integral_constant<bool, Expected>, std::uses_allocator<T, A> >::value, "");
 #if TEST_STD_VER > 14
+    ASSERT_SAME_TYPE(decltype(std::uses_allocator_v<T, A>), const bool);
     static_assert((std::uses_allocator_v<T, A> == Expected), "");
 #endif
 }


### PR DESCRIPTION
`is_placeholder`, despite having an "is_" name, actually returns an int: 1 for `_1`, 2 for `_2`, 3 for `_3`, and so on. But it should still be int, not size_t.