### PR TITLE
[libc++] [P1206] Implement `container-compatible-range` and the `from_range` tag type

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -521,6 +521,7 @@ set(files
   __ranges/as_rvalue_view.h
   __ranges/common_view.h
   __ranges/concepts.h
+  __ranges/container_compatible_range.h
   __ranges/copyable_box.h
   __ranges/counted.h
   __ranges/dangling.h
@@ -533,6 +534,7 @@ set(files
   __ranges/enable_borrowed_range.h
   __ranges/enable_view.h
   __ranges/filter_view.h
+  __ranges/from_range.h
   __ranges/iota_view.h
   __ranges/istream_view.h
   __ranges/join_view.h

--- a/libcxx/include/__ranges/container_compatible_range.h
+++ b/libcxx/include/__ranges/container_compatible_range.h
@@ -1,0 +1,32 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___RANGES_CONTAINER_COMPATIBLE_RANGE_H
+#define _LIBCPP___RANGES_CONTAINER_COMPATIBLE_RANGE_H
+
+#include <__concepts/convertible_to.h>
+#include <__config>
+#include <__ranges/concepts.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+#if _LIBCPP_STD_VER >= 23
+
+template <class _Rp, class _Tp>
+concept __container_compatible_range = ranges::input_range<_Rp> && convertible_to<ranges::range_reference_t<_Rp>, _Tp>;
+
+#endif // _LIBCPP_STD_VER >= 23
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___RANGES_CONTAINER_COMPATIBLE_RANGE_H

--- a/libcxx/include/__ranges/from_range.h
+++ b/libcxx/include/__ranges/from_range.h
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___UTILITY_FROM_RANGE_H
+#define _LIBCPP___UTILITY_FROM_RANGE_H
+
+#include <__config>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+#if _LIBCPP_STD_VER >= 23
+
+struct _LIBCPP_TYPE_VIS from_range_t {
+  explicit from_range_t() = default;
+};
+inline constexpr from_range_t from_range{};
+
+#endif // _LIBCPP_STD_VER >= 23
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___UTILITY_FROM_RANGE_H

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -1269,6 +1269,7 @@ module std [system] {
       module as_rvalue_view         { private header "__ranges/as_rvalue_view.h" }
       module common_view            { private header "__ranges/common_view.h" }
       module concepts               { private header "__ranges/concepts.h" }
+      module container_compatible_range { private header "__ranges/container_compatible_range.h" }
       module copyable_box           { private header "__ranges/copyable_box.h" }
       module counted                {
         private header "__ranges/counted.h"
@@ -1284,6 +1285,7 @@ module std [system] {
       module enable_borrowed_range  { private header "__ranges/enable_borrowed_range.h" }
       module enable_view            { private header "__ranges/enable_view.h" }
       module filter_view            { private header "__ranges/filter_view.h" }
+      module from_range             { private header "__ranges/from_range.h" }
       module iota_view              { private header "__ranges/iota_view.h" }
       module istream_view           {
         @requires_LIBCXX_ENABLE_LOCALIZATION@

--- a/libcxx/include/ranges
+++ b/libcxx/include/ranges
@@ -360,6 +360,7 @@ namespace std {
 #include <__ranges/enable_borrowed_range.h>
 #include <__ranges/enable_view.h>
 #include <__ranges/filter_view.h>
+#include <__ranges/from_range.h>
 #include <__ranges/iota_view.h>
 #include <__ranges/join_view.h>
 #include <__ranges/lazy_split_view.h>

--- a/libcxx/test/libcxx/private_headers.verify.cpp
+++ b/libcxx/test/libcxx/private_headers.verify.cpp
@@ -552,6 +552,7 @@ END-SCRIPT
 #include <__ranges/as_rvalue_view.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/as_rvalue_view.h'}}
 #include <__ranges/common_view.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/common_view.h'}}
 #include <__ranges/concepts.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/concepts.h'}}
+#include <__ranges/container_compatible_range.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/container_compatible_range.h'}}
 #include <__ranges/copyable_box.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/copyable_box.h'}}
 #include <__ranges/counted.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/counted.h'}}
 #include <__ranges/dangling.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/dangling.h'}}
@@ -564,6 +565,7 @@ END-SCRIPT
 #include <__ranges/enable_borrowed_range.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/enable_borrowed_range.h'}}
 #include <__ranges/enable_view.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/enable_view.h'}}
 #include <__ranges/filter_view.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/filter_view.h'}}
+#include <__ranges/from_range.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/from_range.h'}}
 #include <__ranges/iota_view.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/iota_view.h'}}
 #include <__ranges/istream_view.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/istream_view.h'}}
 #include <__ranges/join_view.h> // expected-error@*:* {{use of private header from outside its module: '__ranges/join_view.h'}}

--- a/libcxx/test/std/ranges/range.utility/range.utility.conv/range.utility.conv.general/from_range.pass.cpp
+++ b/libcxx/test/std/ranges/range.utility/range.utility.conv/range.utility.conv.general/from_range.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+
+// <ranges>
+
+// struct from_range_t { explicit from_range_t() = default; };
+// inline constexpr from_range_t from_range{};
+
+#include <cassert>
+#include <type_traits>
+#include <ranges>
+
+#include "test_macros.h"
+
+constexpr bool usable_in_constexpr(std::from_range_t) { return true; }
+
+template <class T>
+concept convertible_from_empty_braces = requires(void (*f)(T)) {
+  f({});
+};
+
+int main(int, char**) {
+  ASSERT_SAME_TYPE(decltype(std::from_range), const std::from_range_t);
+  static_assert(usable_in_constexpr(std::from_range));
+  static_assert(usable_in_constexpr(std::from_range_t()));
+  static_assert(!convertible_from_empty_braces<std::from_range_t>);
+
+  std::from_range_t fr;
+  auto fr2 = fr;
+  (void)fr2;
+
+  return 0;
+}


### PR DESCRIPTION
This is just enough of P1206 to support adding the new constructors and methods to new and/or existing containers piecemeal. No existing container has yet been touched.