### PR TITLE
[libc++] [test] Counter<T>'s assignment operator shouldn't ++gConstructed

### DIFF
--- a/libcxx/test/support/Counter.h
+++ b/libcxx/test/support/Counter.h
@@ -25,7 +25,7 @@ public:
     Counter& operator=(const Counter& rhs)          { data_ = rhs.data_; return *this; }
 #if TEST_STD_VER >= 11
     Counter(Counter&& rhs) : data_(std::move(rhs.data_))  { ++gConstructed; }
-    Counter& operator=(Counter&& rhs) { ++gConstructed; data_ = std::move(rhs.data_); return *this; }
+    Counter& operator=(Counter&& rhs) { data_ = std::move(rhs.data_); return *this; }
 #endif
     ~Counter() { --gConstructed; }
 


### PR DESCRIPTION
This has been here since d5f461ca03e30, but assigning into an existing Counter object definitely doesn't create a new object. This causes the count to "leak" higher and higher, inside algorithms based on swapping.