### PR TITLE
[libc++] [test] Refactor allocator_mismatch.compile.fail.cpp -> .verify.cpp

### DIFF
--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -482,14 +482,6 @@ protected:
     typedef typename allocator_traits<__begin_node_allocator>::pointer
                                                       __begin_node_pointer;
 
-    static_assert((!is_same<allocator_type, __node_allocator>::value),
-                  "internal allocator type must differ from user-specified "
-                  "type; otherwise overload resolution breaks");
-
-    static_assert(is_same<allocator_type, __rebind_alloc<__node_traits, value_type> >::value,
-                  "[allocator.requirements] states that rebinding an allocator to the same type should result in the "
-                  "original allocator");
-
     __compressed_pair<__begin_node, __node_allocator> __before_begin_;
 
     _LIBCPP_INLINE_VISIBILITY
@@ -659,8 +651,16 @@ public:
     typedef _Tp    value_type;
     typedef _Alloc allocator_type;
 
-    static_assert((is_same<typename allocator_type::value_type, value_type>::value),
+    static_assert(is_same<value_type, typename allocator_type::value_type>::value,
                   "Allocator::value_type must be same type as value_type");
+
+    static_assert(is_same<allocator_type, __rebind_alloc<allocator_traits<allocator_type>, value_type> >::value,
+                  "[allocator.requirements] states that rebinding an allocator to the same type should result in the "
+                  "original allocator");
+
+    static_assert((!is_same<allocator_type, __node_allocator>::value),
+                  "internal allocator type must differ from user-specified "
+                  "type; otherwise overload resolution breaks");
 
     typedef value_type&                                                 reference;
     typedef const value_type&                                           const_reference;

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -824,7 +824,7 @@ public:
     typedef _Tp                                            value_type;
     typedef _Alloc                                         allocator_type;
     static_assert((is_same<value_type, typename allocator_type::value_type>::value),
-                  "Invalid allocator::value_type");
+                  "Allocator::value_type must be same type as value_type");
     typedef value_type&                                    reference;
     typedef const value_type&                              const_reference;
     typedef typename base::pointer                         pointer;

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -1035,7 +1035,7 @@ public:
     typedef value_type&                                    reference;
     typedef const value_type&                              const_reference;
     static_assert((is_same<value_type, typename allocator_type::value_type>::value),
-                  "Invalid allocator::value_type");
+                  "Allocator::value_type must be same type as value_type");
 
 private:
     typedef __hash_value_type<key_type, mapped_type>                          __value_type;
@@ -1928,7 +1928,7 @@ public:
     typedef value_type&                                    reference;
     typedef const value_type&                              const_reference;
     static_assert((is_same<value_type, typename allocator_type::value_type>::value),
-                  "Invalid allocator::value_type");
+                  "Allocator::value_type must be same type as value_type");
 
 private:
     typedef __hash_value_type<key_type, mapped_type>                          __value_type;

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -513,7 +513,7 @@ public:
     typedef value_type&                                                reference;
     typedef const value_type&                                          const_reference;
     static_assert((is_same<value_type, typename allocator_type::value_type>::value),
-                  "Invalid allocator::value_type");
+                  "Allocator::value_type must be same type as value_type");
 
     static_assert(is_same<allocator_type, __rebind_alloc<allocator_traits<allocator_type>, value_type> >::value,
                   "[allocator.requirements] states that rebinding an allocator to the same type should result in the "
@@ -1173,7 +1173,7 @@ public:
     typedef value_type&                                                reference;
     typedef const value_type&                                          const_reference;
     static_assert((is_same<value_type, typename allocator_type::value_type>::value),
-                  "Invalid allocator::value_type");
+                  "Allocator::value_type must be same type as value_type");
 
 private:
     typedef __hash_table<value_type, hasher, key_equal, allocator_type> __table;

--- a/libcxx/test/std/containers/associative/map/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/map/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <set>
+// <map>
 //   The container's value type must be the same as the allocator's value type
 
-#include <set>
+#include <map>
 
-int main(int, char**)
-{
-    std::set<int, std::less<int>, std::allocator<long> > s;
-
-  return 0;
-}
+std::map<int, int, std::less<int>, std::allocator<long> > m;
+  // expected-error-re@map:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/associative/multimap/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/multimap/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <unordered_set>
+// <map>
 //   The container's value type must be the same as the allocator's value type
 
-#include <unordered_set>
+#include <map>
 
-int main(int, char**)
-{
-    std::unordered_set<int, std::hash<int>, std::less<int>, std::allocator<long> > v;
-
-  return 0;
-}
+std::multimap<int, int, std::less<int>, std::allocator<long> > m;
+  // expected-error-re@map:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/associative/multiset/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/multiset/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <unordered_map>
+// <set>
 //   The container's value type must be the same as the allocator's value type
 
-#include <unordered_map>
+#include <set>
 
-int main(int, char**)
-{
-    std::unordered_map<int, int, std::hash<int>, std::less<int>, std::allocator<long> > m;
-
-  return 0;
-}
+std::multiset<int, std::less<int>, std::allocator<long> > m;
+  // expected-error-re@set:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/associative/set/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/associative/set/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <forward_list>
+// <set>
 //   The container's value type must be the same as the allocator's value type
 
-#include <forward_list>
+#include <set>
 
-int main(int, char**)
-{
-    std::forward_list<int, std::allocator<long> > fl;
-
-  return 0;
-}
+std::set<int, std::less<int>, std::allocator<long> > m;
+  // expected-error-re@set:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/associative/set/range_concept_conformance.compile.pass.cpp
+++ b/libcxx/test/std/containers/associative/set/range_concept_conformance.compile.pass.cpp
@@ -32,7 +32,7 @@ static_assert(std::same_as<std::ranges::iterator_t<range const>, range::const_it
 static_assert(std::ranges::bidirectional_range<range const>);
 static_assert(!std::ranges::random_access_range<range const>);
 static_assert(std::ranges::common_range<range const>);
-static_assert(std::ranges::input_range<range>);
+static_assert(std::ranges::input_range<range const>);
 static_assert(!std::ranges::view<range const>);
 static_assert(std::ranges::sized_range<range const>);
 static_assert(!std::ranges::borrowed_range<range const>);

--- a/libcxx/test/std/containers/sequences/deque/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/deque/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <map>
+// <deque>
 //   The container's value type must be the same as the allocator's value type
 
-#include <map>
+#include <deque>
 
-int main(int, char**)
-{
-    std::map<int, int, std::less<int>, std::allocator<long> > m;
-
-  return 0;
-}
+std::deque<int, std::allocator<long> > d;
+  // expected-error-re@deque:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/sequences/forwardlist/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/forwardlist/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <set>
+// <forward_list>
 //   The container's value type must be the same as the allocator's value type
 
-#include <set>
+#include <forward_list>
 
-int main(int, char**)
-{
-    std::multiset<int, std::less<int>, std::allocator<long> > ms;
-
-  return 0;
-}
+std::forward_list<int, std::allocator<long> > fl;
+  // expected-error-re@forward_list:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/sequences/list/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/list/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <vector>
+// <list>
 //   The container's value type must be the same as the allocator's value type
 
-#include <vector>
+#include <list>
 
-int main(int, char**)
-{
-    std::vector<int, std::allocator<long> > v;
-
-  return 0;
-}
+std::list<int, std::allocator<long> > l;
+  // expected-error-re@list:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/sequences/vector/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/sequences/vector/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <deque>
+// <vector>
 //   The container's value type must be the same as the allocator's value type
 
-#include <deque>
+#include <vector>
 
-int main(int, char**)
-{
-    std::deque<int, std::allocator<long> > d;
-
-  return 0;
-}
+std::vector<int, std::allocator<long> > v;
+  // expected-error-re@vector:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.map/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/allocator_mismatch.verify.cpp
@@ -11,9 +11,5 @@
 
 #include <unordered_map>
 
-int main(int, char**)
-{
-    std::unordered_multimap<int, int, std::hash<int>, std::less<int>, std::allocator<long> > m;
-
-  return 0;
-}
+std::unordered_map<int, int, std::hash<int>, std::less<int>, std::allocator<long> > m;
+  // expected-error-re@unordered_map:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.multimap/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <list>
+// <unordered_map>
 //   The container's value type must be the same as the allocator's value type
 
-#include <list>
+#include <unordered_map>
 
-int main(int, char**)
-{
-    std::list<int, std::allocator<long> > l;
-
-  return 0;
-}
+std::unordered_multimap<int, int, std::hash<int>, std::less<int>, std::allocator<long> > m;
+  // expected-error-re@unordered_map:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.multiset/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.multiset/allocator_mismatch.verify.cpp
@@ -11,9 +11,5 @@
 
 #include <unordered_set>
 
-int main(int, char**)
-{
-    std::unordered_multiset<int, std::hash<int>, std::less<int>, std::allocator<long> > v;
-
-  return 0;
-}
+std::unordered_multiset<int, std::hash<int>, std::less<int>, std::allocator<long> > v;
+  // expected-error-re@unordered_set:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}

--- a/libcxx/test/std/containers/unord/unord.set/allocator_mismatch.verify.cpp
+++ b/libcxx/test/std/containers/unord/unord.set/allocator_mismatch.verify.cpp
@@ -6,14 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <map>
+// <unordered_set>
 //   The container's value type must be the same as the allocator's value type
 
-#include <map>
+#include <unordered_set>
 
-int main(int, char**)
-{
-    std::multimap<int, int, std::less<int>, std::allocator<long> > m;
-
-  return 0;
-}
+std::unordered_set<int, std::hash<int>, std::less<int>, std::allocator<long> > v;
+  // expected-error-re@unordered_set:* {{static assertion failed {{.*}}: Allocator::value_type must be same type as value_type}}


### PR DESCRIPTION
Notice the harmonizing changes in `<unordered_*>` and the slightly more invasive harmonizing change in `<forward_list>`.

Also, the second commit in this PR adds a missing `const` to one of the ranges-concepts tests, as long as we're touching tests.
