### PR TITLE
[libc++] [test] Rename set/map scary.pass.cpp compile-only tests

### DIFF
--- a/libcxx/test/libcxx/containers/associative/map/scary.compile.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/map/scary.compile.pass.cpp
@@ -8,7 +8,8 @@
 
 // <map>
 
-// class map class multimap
+// class map
+// class multimap
 
 // Extension:  SCARY/N2913 iterator compatibility between map and multimap
 
@@ -16,13 +17,9 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    typedef std::map<int, int> M1;
-    typedef std::multimap<int, int> M2;
-    M2::iterator i;
-    M1::iterator j = i;
-    ((void)j);
-
-  return 0;
+void test() {
+  typedef std::map<int, int> M1;
+  typedef std::multimap<int, int> M2;
+  ASSERT_SAME_TYPE(M1::iterator, M2::iterator);
+  ASSERT_SAME_TYPE(M1::const_iterator, M2::const_iterator);
 }

--- a/libcxx/test/libcxx/containers/associative/set/scary.compile.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/set/scary.compile.pass.cpp
@@ -6,23 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <unordered_set>
+// <set>
 
-// class unordered_set class unordered_multiset
+// class set
+// class multiset
 
-// Extension:  SCARY/N2913 iterator compatibility between unordered_set and unordered_multiset
+// Extension:  SCARY/N2913 iterator compatibility between set and multiset
 
-#include <unordered_set>
+#include <set>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    typedef std::unordered_set<int> M1;
-    typedef std::unordered_multiset<int> M2;
-    M2::iterator i;
-    M1::iterator j = i;
-    ((void)j);
-
-  return 0;
+void test() {
+  typedef std::set<int> M1;
+  typedef std::multiset<int> M2;
+  ASSERT_SAME_TYPE(M1::iterator, M2::iterator);
+  ASSERT_SAME_TYPE(M1::const_iterator, M2::const_iterator);
 }

--- a/libcxx/test/libcxx/containers/unord/unord.map/scary.compile.pass.cpp
+++ b/libcxx/test/libcxx/containers/unord/unord.map/scary.compile.pass.cpp
@@ -8,7 +8,8 @@
 
 // <unordered_map>
 
-// class unordered_map class unordered_multimap
+// class unordered_map
+// class unordered_multimap
 
 // Extension:  SCARY/N2913 iterator compatibility between unordered_map and unordered_multimap
 
@@ -16,13 +17,9 @@
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    typedef std::unordered_map<int, int> M1;
-    typedef std::unordered_multimap<int, int> M2;
-    M2::iterator i;
-    M1::iterator j = i;
-    ((void)j);
-
-  return 0;
+void test() {
+  typedef std::unordered_map<int, int> M1;
+  typedef std::unordered_multimap<int, int> M2;
+  ASSERT_SAME_TYPE(M1::iterator, M2::iterator);
+  ASSERT_SAME_TYPE(M1::const_iterator, M2::const_iterator);
 }

--- a/libcxx/test/libcxx/containers/unord/unord.set/scary.compile.pass.cpp
+++ b/libcxx/test/libcxx/containers/unord/unord.set/scary.compile.pass.cpp
@@ -6,23 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-// <set>
+// <unordered_set>
 
-// class set class multiset
+// class unordered_set
+// class unordered_multiset
 
-// Extension:  SCARY/N2913 iterator compatibility between set and multiset
+// Extension:  SCARY/N2913 iterator compatibility between unordered_set and unordered_multiset
 
-#include <set>
+#include <unordered_set>
 
 #include "test_macros.h"
 
-int main(int, char**)
-{
-    typedef std::set<int> M1;
-    typedef std::multiset<int> M2;
-    M2::iterator i;
-    M1::iterator j = i;
-    ((void)j);
-
-  return 0;
+void test() {
+  typedef std::unordered_set<int> M1;
+  typedef std::unordered_multiset<int> M2;
+  ASSERT_SAME_TYPE(M1::iterator, M2::iterator);
+  ASSERT_SAME_TYPE(M1::const_iterator, M2::const_iterator);
 }


### PR DESCRIPTION
These tests are compile-only, and also libc++-specific, so move them from `test/std/` to `test/libcxx/` and rename them to `.compile.pass.cpp`. Also some drive-by reformatting.