### PR TITLE
[libc++] scoped_allocator_adaptor(Convertible, Convertible) shouldn't be ambiguous

### DIFF
--- a/libcxx/include/scoped_allocator
+++ b/libcxx/include/scoped_allocator
@@ -577,14 +577,10 @@ public:
         {return base::select_on_container_copy_construction();}
 
 private:
-
-
-    template <class _OuterA2,
-              __enable_if_t<is_constructible<outer_allocator_type, _OuterA2>::value, int> = 0>
     _LIBCPP_INLINE_VISIBILITY
-    scoped_allocator_adaptor(_OuterA2&& __o,
-                             const inner_allocator_type& __i) _NOEXCEPT
-        : base(_VSTD::forward<_OuterA2>(__o), __i) {}
+    explicit scoped_allocator_adaptor(outer_allocator_type&& __o,
+                                      inner_allocator_type&& __i) _NOEXCEPT
+        : base(std::move(__o), std::move(__i)) {}
 
     template <class _Tp, class... _Args>
         _LIBCPP_INLINE_VISIBILITY

--- a/libcxx/test/std/utilities/allocator.adaptor/allocator.adaptor.cnstr/allocs.pass.cpp
+++ b/libcxx/test/std/utilities/allocator.adaptor/allocator.adaptor.cnstr/allocs.pass.cpp
@@ -107,12 +107,19 @@ int main(int, char**)
         assert((a.inner_allocator() ==
             std::scoped_allocator_adaptor<A2<int>, A3<int>>(A2<int>(5), A3<int>(6))));
     }
-//  Test for LWG2782
     {
+        // Test for LWG2782
         static_assert(!std::is_convertible<A1<int>, A2<int>>::value, "");
         static_assert(!std::is_convertible<
              std::scoped_allocator_adaptor<A1<int>>,
              std::scoped_allocator_adaptor<A2<int>>>::value, "");
+    }
+    {
+        // Test construction from convertible-to-allocator types
+        typedef std::scoped_allocator_adaptor<A1<int>, A1<int>> A;
+        A a(A1<char>(4), A1<char>(5));
+        assert(a.outer_allocator() == A1<int>(4));
+        assert(a.inner_allocator() == A1<int>(5));
     }
 
   return 0;


### PR DESCRIPTION
Reported on Slack 2023-05-30:
https://cpplang.slack.com/archives/CM2HTSZ6G/p1685479237544319

The updated test fails before this patch, and passes afterward.

For a real-world example, see https://godbolt.org/z/1Ev8ch3Wx