### PR TITLE
[libc++] Make `expected` trivially assignable whenever possible

### DIFF
--- a/libcxx/include/__expected/expected.h
+++ b/libcxx/include/__expected/expected.h
@@ -31,6 +31,7 @@
 #include <__type_traits/is_reference.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_swappable.h>
+#include <__type_traits/is_trivially_assignable.h>
 #include <__type_traits/is_trivially_constructible.h>
 #include <__type_traits/is_trivially_destructible.h>
 #include <__type_traits/is_trivially_relocatable.h>
@@ -215,18 +216,24 @@ class __expected_base {
   // it's not clear that it's implementable, given that the function is allowed to clobber
   // the tail padding) - see https://github.com/itanium-cxx-abi/cxx-abi/issues/107.
   union __union_t {
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t(const __union_t&) = delete;
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t(const __union_t&)
-      requires(is_copy_constructible_v<_Tp> && is_copy_constructible_v<_Err> &&
-               is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_constructible_v<_Err>)
+    __union_t(const __union_t&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __union_t(const __union_t&)
+      requires(is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_constructible_v<_Err>)
     = default;
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t(__union_t&&) = delete;
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t(__union_t&&)
-      requires(is_move_constructible_v<_Tp> && is_move_constructible_v<_Err> &&
-               is_trivially_move_constructible_v<_Tp> && is_trivially_move_constructible_v<_Err>)
+    __union_t(__union_t&&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __union_t(__union_t&&)
+      requires(is_trivially_move_constructible_v<_Tp> && is_trivially_move_constructible_v<_Err>)
     = default;
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t& operator=(const __union_t&) = delete;
-    _LIBCPP_HIDE_FROM_ABI constexpr __union_t& operator=(__union_t&&)      = delete;
+    __union_t& operator=(const __union_t&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __union_t& operator=(const __union_t&)
+      requires(is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_constructible_v<_Err> &&
+               is_trivially_copy_assignable_v<_Tp> && is_trivially_copy_assignable_v<_Err>)
+    = default;
+    __union_t& operator=(__union_t&&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __union_t& operator=(__union_t&&)
+      requires(is_trivially_move_constructible_v<_Tp> && is_trivially_move_constructible_v<_Err> &&
+               is_trivially_move_assignable_v<_Tp> && is_trivially_move_assignable_v<_Err>)
+    = default;
 
     template <class... _Args>
     _LIBCPP_HIDE_FROM_ABI constexpr explicit __union_t(in_place_t, _Args&&... __args)
@@ -293,19 +300,24 @@ class __expected_base {
                    [&] { return __make_union(__has_val, std::forward<_OtherUnion>(__other)); }),
           __has_val_(__has_val) {}
 
-    _LIBCPP_HIDE_FROM_ABI constexpr __repr(const __repr&) = delete;
-    _LIBCPP_HIDE_FROM_ABI constexpr __repr(const __repr&)
-      requires(is_copy_constructible_v<_Tp> && is_copy_constructible_v<_Err> &&
-               is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_constructible_v<_Err>)
+    __repr(const __repr&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __repr(const __repr&)
+      requires is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_constructible_v<_Err>
     = default;
-    _LIBCPP_HIDE_FROM_ABI constexpr __repr(__repr&&) = delete;
-    _LIBCPP_HIDE_FROM_ABI constexpr __repr(__repr&&)
-      requires(is_move_constructible_v<_Tp> && is_move_constructible_v<_Err> &&
-               is_trivially_move_constructible_v<_Tp> && is_trivially_move_constructible_v<_Err>)
+    __repr(__repr&&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __repr(__repr&&)
+      requires is_trivially_move_constructible_v<_Tp> && is_trivially_move_constructible_v<_Err>
     = default;
-
-    _LIBCPP_HIDE_FROM_ABI constexpr __repr& operator=(const __repr&) = delete;
-    _LIBCPP_HIDE_FROM_ABI constexpr __repr& operator=(__repr&&)      = delete;
+    __repr& operator=(const __repr&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __repr& operator=(const __repr&)
+      requires is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_assignable_v<_Tp> &&
+               is_trivially_copy_constructible_v<_Err> && is_trivially_copy_assignable_v<_Err>
+    = default;
+    __repr& operator=(__repr&&) = delete;
+    _LIBCPP_HIDE_FROM_ABI __repr& operator=(__repr&&)
+      requires is_trivially_move_constructible_v<_Tp> && is_trivially_move_assignable_v<_Tp> &&
+               is_trivially_move_constructible_v<_Err> && is_trivially_move_assignable_v<_Err>
+    = default;
 
     _LIBCPP_HIDE_FROM_ABI constexpr ~__repr()
       requires(is_trivially_destructible_v<_Tp> && is_trivially_destructible_v<_Err>)
@@ -444,6 +456,19 @@ protected:
 private:
   _LIBCPP_NO_UNIQUE_ADDRESS __conditional_no_unique_address<__allow_reusing_expected_tail_padding, __repr> __repr_;
 };
+
+template<class _Tp, class _Err>
+concept __expected_have_copy_assignment =
+    is_copy_constructible_v<_Tp> && is_copy_assignable_v<_Tp> &&
+    is_copy_constructible_v<_Err> && is_copy_assignable_v<_Err> &&
+    (is_nothrow_move_constructible_v<_Tp> || is_nothrow_move_constructible_v<_Err>);
+
+template<class _Tp, class _Err>
+concept __expected_have_move_assignment =
+    is_move_constructible_v<_Tp> && is_move_assignable_v<_Tp> &&
+    is_move_constructible_v<_Err> && is_move_assignable_v<_Err> &&
+    (is_nothrow_move_constructible_v<_Tp> || is_nothrow_move_constructible_v<_Err>);
+
 
 template <class _Tp, class _Err>
 class expected : private __expected_base<_Tp, _Err> {
@@ -629,9 +654,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr expected& operator=(const expected& __rhs) noexcept(
       is_nothrow_copy_assignable_v<_Tp> && is_nothrow_copy_constructible_v<_Tp> && is_nothrow_copy_assignable_v<_Err> &&
       is_nothrow_copy_constructible_v<_Err>) // strengthened
-    requires(is_copy_assignable_v<_Tp> && is_copy_constructible_v<_Tp> && is_copy_assignable_v<_Err> &&
-             is_copy_constructible_v<_Err> &&
-             (is_nothrow_move_constructible_v<_Tp> || is_nothrow_move_constructible_v<_Err>))
+    requires __expected_have_copy_assignment<_Tp, _Err>
   {
     if (this->__has_val() && __rhs.__has_val()) {
       this->__val() = __rhs.__val();
@@ -645,12 +668,16 @@ public:
     return *this;
   }
 
+  _LIBCPP_HIDE_FROM_ABI constexpr expected& operator=(const expected& __rhs)
+    requires __expected_have_copy_assignment<_Tp, _Err> &&
+      is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_assignable_v<_Tp> &&
+      is_trivially_copy_constructible_v<_Err> && is_trivially_copy_assignable_v<_Err>
+  = default;
+
   _LIBCPP_HIDE_FROM_ABI constexpr expected&
   operator=(expected&& __rhs) noexcept(is_nothrow_move_assignable_v<_Tp> && is_nothrow_move_constructible_v<_Tp> &&
                                        is_nothrow_move_assignable_v<_Err> && is_nothrow_move_constructible_v<_Err>)
-    requires(is_move_constructible_v<_Tp> && is_move_assignable_v<_Tp> && is_move_constructible_v<_Err> &&
-             is_move_assignable_v<_Err> &&
-             (is_nothrow_move_constructible_v<_Tp> || is_nothrow_move_constructible_v<_Err>))
+    requires __expected_have_move_assignment<_Tp, _Err>
   {
     if (this->__has_val() && __rhs.__has_val()) {
       this->__val() = std::move(__rhs.__val());
@@ -663,6 +690,12 @@ public:
     }
     return *this;
   }
+
+  _LIBCPP_HIDE_FROM_ABI constexpr expected& operator=(expected&& __rhs)
+    requires __expected_have_move_assignment<_Tp, _Err> &&
+      is_trivially_move_constructible_v<_Tp> && is_trivially_move_assignable_v<_Tp> &&
+      is_trivially_move_constructible_v<_Err> && is_trivially_move_assignable_v<_Err>
+  = default;
 
   template <class _Up = _Tp>
   _LIBCPP_HIDE_FROM_ABI constexpr expected& operator=(_Up&& __v)

--- a/libcxx/test/std/utilities/expected/expected.expected/assign/assign.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/assign/assign.copy.pass.cpp
@@ -28,6 +28,12 @@
 // - is_copy_assignable_v<E> is true and
 // - is_copy_constructible_v<E> is true and
 // - is_nothrow_move_constructible_v<T> || is_nothrow_move_constructible_v<E> is true.
+//
+// This assignment operator is trivial if
+// - is_trivially_copy_constructible_v<T> is true and
+// - is_trivially_copy_constructible_v<E> is true and
+// - is_trivially_copy_assignable_v<T> is true and
+// - is_trivially_copy_assignable_v<E> is true.
 
 #include <cassert>
 #include <concepts>
@@ -55,6 +61,28 @@ struct MoveMayThrow {
   MoveMayThrow& operator=(MoveMayThrow&&) noexcept(false) { return *this; }
 };
 
+template<int N>
+struct CopyableNonTrivial {
+  int i;
+  char pad[N];
+  constexpr CopyableNonTrivial(int ii) : i(ii) {}
+  constexpr CopyableNonTrivial(const CopyableNonTrivial& o) { i = o.i; }
+  CopyableNonTrivial(CopyableNonTrivial&&) = default;
+  constexpr void operator=(const CopyableNonTrivial& o) { i = o.i; }
+  CopyableNonTrivial& operator=(CopyableNonTrivial&&) = default;
+};
+
+template<int N>
+struct MovableNonTrivial {
+  int i;
+  char pad[N];
+  constexpr MovableNonTrivial(int ii) : i(ii) {}
+  MovableNonTrivial(const MovableNonTrivial&) = default;
+  constexpr MovableNonTrivial(MovableNonTrivial&& o) noexcept { i = o.i; }
+  MovableNonTrivial& operator=(const MovableNonTrivial&) = default;
+  constexpr void operator=(MovableNonTrivial&& o) { i = o.i; }
+};
+
 // Test constraints
 static_assert(std::is_copy_assignable_v<std::expected<int, int>>);
 
@@ -78,6 +106,25 @@ static_assert(std::is_copy_assignable_v<std::expected<int, MoveMayThrow>>);
 
 // !is_nothrow_move_constructible_v<T> && !is_nothrow_move_constructible_v<E>
 static_assert(!std::is_copy_assignable_v<std::expected<MoveMayThrow, MoveMayThrow>>);
+
+// Test: This constructor is trivial if
+// - is_trivially_copy_constructible_v<T> is true and
+// - is_trivially_copy_constructible_v<E> is true and
+// - is_trivially_copy_assignable_v<T> is true and
+// - is_trivially_copy_assignable_v<E> is true.
+static_assert(std::is_trivially_copy_assignable_v<std::expected<int, int>>);
+static_assert(!std::is_trivially_copy_assignable_v<std::expected<CopyableNonTrivial<1>, int>>);
+static_assert(!std::is_trivially_copy_assignable_v<std::expected<int, CopyableNonTrivial<1>>>);
+static_assert(!std::is_trivially_copy_assignable_v<std::expected<CopyableNonTrivial<1>, CopyableNonTrivial<1>>>);
+static_assert(std::is_trivially_copy_assignable_v<std::expected<MovableNonTrivial<1>, int>>);
+static_assert(std::is_trivially_copy_assignable_v<std::expected<int, MovableNonTrivial<1>>>);
+static_assert(std::is_trivially_copy_assignable_v<std::expected<MovableNonTrivial<1>, MovableNonTrivial<1>>>);
+static_assert(!std::is_trivially_copy_assignable_v<std::expected<CopyableNonTrivial<4>, int>>);
+static_assert(!std::is_trivially_copy_assignable_v<std::expected<int, CopyableNonTrivial<4>>>);
+static_assert(!std::is_trivially_copy_assignable_v<std::expected<CopyableNonTrivial<4>, CopyableNonTrivial<4>>>);
+static_assert(std::is_trivially_copy_assignable_v<std::expected<MovableNonTrivial<4>, int>>);
+static_assert(std::is_trivially_copy_assignable_v<std::expected<int, MovableNonTrivial<4>>>);
+static_assert(std::is_trivially_copy_assignable_v<std::expected<MovableNonTrivial<4>, MovableNonTrivial<4>>>);
 
 constexpr bool test() {
   // If this->has_value() && rhs.has_value() is true, equivalent to val = *rhs.


### PR DESCRIPTION
Since @huixie90 asked for a proof of concept — here it is!

Note that `=delete`d functions don't need to be hidden from ABI, nor do they need to be constexpr or noexcept or have any particular return type. Note that `=default`ed functions shouldn't be explicitly marked constexpr or noexcept.